### PR TITLE
feat: add spark history server api

### DIFF
--- a/examples/ibm-analytics-engine-api.v3.test.js
+++ b/examples/ibm-analytics-engine-api.v3.test.js
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 /**
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -350,7 +350,7 @@ describe('IbmAnalyticsEngineApiV3', () => {
 
     const params = {
       instanceId: 'dc0e9889-eab2-4t9e-9441-566209499546',
-      state: ['accepted', 'submitted', 'waiting', 'running', 'finished', 'failed'],
+      state: ['accepted', 'running', 'finished', 'failed'],
     };
 
     let res;
@@ -590,6 +590,87 @@ describe('IbmAnalyticsEngineApiV3', () => {
     }
 
     // end-get_logging_configuration
+  });
+
+  test('startSparkHistoryServer request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('startSparkHistoryServer() result:');
+    // begin-start_spark_history_server
+
+    const params = {
+      instanceId: 'dc0e9889-eab2-4t9e-9441-566209499546',
+    };
+
+    let res;
+    try {
+      res = await ibmAnalyticsEngineApiService.startSparkHistoryServer(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-start_spark_history_server
+  });
+
+  test('getSparkHistoryServer request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('getSparkHistoryServer() result:');
+    // begin-get_spark_history_server
+
+    const params = {
+      instanceId: 'dc0e9889-eab2-4t9e-9441-566209499546',
+    };
+
+    let res;
+    try {
+      res = await ibmAnalyticsEngineApiService.getSparkHistoryServer(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-get_spark_history_server
+  });
+
+  test('stopSparkHistoryServer request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    // begin-stop_spark_history_server
+
+    const params = {
+      instanceId: 'dc0e9889-eab2-4t9e-9441-566209499546',
+    };
+
+    try {
+      await ibmAnalyticsEngineApiService.stopSparkHistoryServer(params);
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-stop_spark_history_server
   });
 
   test('deleteApplication request example', async () => {

--- a/ibm-analytics-engine-api/v3.ts
+++ b/ibm-analytics-engine-api/v3.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1094,6 +1094,7 @@ class IbmAnalyticsEngineApiV3 extends BaseService {
    * Enable or disable log forwarding.
    *
    * Enable or disable log forwarding from IBM Analytics Engine to IBM Log Analysis server.
+   * *Note:* Deprecated. Use the log forwarding config api instead.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.instanceGuid - GUID of the instance details for which log forwarding is to be configured.
@@ -1155,6 +1156,7 @@ class IbmAnalyticsEngineApiV3 extends BaseService {
    * Retrieve the logging configuration for a given instance id.
    *
    * Retrieve the logging configuration of a given Analytics Engine instance.
+   * *Note:* Deprecated. Use the log forwarding config api instead.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.instanceGuid - GUID of the Analytics Engine service instance to retrieve log configuration.
@@ -1199,6 +1201,158 @@ class IbmAnalyticsEngineApiV3 extends BaseService {
           },
           _params.headers
         ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Start Spark history server.
+   *
+   * Start the Spark history server for the given Analytics Engine instance.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.instanceId - The ID of the Analytics Engine instance to which the Spark history server
+   * belongs.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IbmAnalyticsEngineApiV3.Response<IbmAnalyticsEngineApiV3.SparkHistoryServerResponse>>}
+   */
+  public startSparkHistoryServer(
+    params: IbmAnalyticsEngineApiV3.StartSparkHistoryServerParams
+  ): Promise<IbmAnalyticsEngineApiV3.Response<IbmAnalyticsEngineApiV3.SparkHistoryServerResponse>> {
+    const _params = { ...params };
+    const _requiredParams = ['instanceId'];
+    const _validParams = ['instanceId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'instance_id': _params.instanceId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IbmAnalyticsEngineApiV3.DEFAULT_SERVICE_NAME,
+      'v3',
+      'startSparkHistoryServer'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v3/analytics_engines/{instance_id}/spark_history_server',
+        method: 'POST',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Get Spark history server details.
+   *
+   * Get the details of the Spark history server of the given Analytics Engine instance.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.instanceId - The ID of the Analytics Engine instance to which the Spark history server
+   * belongs.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IbmAnalyticsEngineApiV3.Response<IbmAnalyticsEngineApiV3.SparkHistoryServerResponse>>}
+   */
+  public getSparkHistoryServer(
+    params: IbmAnalyticsEngineApiV3.GetSparkHistoryServerParams
+  ): Promise<IbmAnalyticsEngineApiV3.Response<IbmAnalyticsEngineApiV3.SparkHistoryServerResponse>> {
+    const _params = { ...params };
+    const _requiredParams = ['instanceId'];
+    const _validParams = ['instanceId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'instance_id': _params.instanceId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IbmAnalyticsEngineApiV3.DEFAULT_SERVICE_NAME,
+      'v3',
+      'getSparkHistoryServer'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v3/analytics_engines/{instance_id}/spark_history_server',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Stop Spark history server.
+   *
+   * Stop the Spark history server of the given Analytics Engine instance.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.instanceId - The ID of the Analytics Engine instance to which the Spark history server
+   * belongs.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IbmAnalyticsEngineApiV3.Response<IbmAnalyticsEngineApiV3.Empty>>}
+   */
+  public stopSparkHistoryServer(
+    params: IbmAnalyticsEngineApiV3.StopSparkHistoryServerParams
+  ): Promise<IbmAnalyticsEngineApiV3.Response<IbmAnalyticsEngineApiV3.Empty>> {
+    const _params = { ...params };
+    const _requiredParams = ['instanceId'];
+    const _validParams = ['instanceId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'instance_id': _params.instanceId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IbmAnalyticsEngineApiV3.DEFAULT_SERVICE_NAME,
+      'v3',
+      'stopSparkHistoryServer'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v3/analytics_engines/{instance_id}/spark_history_server',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(true, sdkHeaders, {}, _params.headers),
       }),
     };
 
@@ -1337,11 +1491,7 @@ namespace IbmAnalyticsEngineApiV3 {
       FINISHED = 'finished',
       RUNNING = 'running',
       FAILED = 'failed',
-      ERROR = 'error',
       ACCEPTED = 'accepted',
-      SUBMITTED = 'submitted',
-      WAITING = 'waiting',
-      UNKNOWN = 'unknown',
       STOPPED = 'stopped',
       AUTO_TERMINATED = 'auto_terminated',
       OPS_TERMINATED = 'ops_terminated',
@@ -1427,6 +1577,27 @@ namespace IbmAnalyticsEngineApiV3 {
     headers?: OutgoingHttpHeaders;
   }
 
+  /** Parameters for the `startSparkHistoryServer` operation. */
+  export interface StartSparkHistoryServerParams {
+    /** The ID of the Analytics Engine instance to which the Spark history server belongs. */
+    instanceId: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `getSparkHistoryServer` operation. */
+  export interface GetSparkHistoryServerParams {
+    /** The ID of the Analytics Engine instance to which the Spark history server belongs. */
+    instanceId: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `stopSparkHistoryServer` operation. */
+  export interface StopSparkHistoryServerParams {
+    /** The ID of the Analytics Engine instance to which the Spark history server belongs. */
+    instanceId: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
   /*************************
    * model interfaces
    ************************/
@@ -1445,12 +1616,18 @@ namespace IbmAnalyticsEngineApiV3 {
     spark_application_name?: string;
     /** State of the Spark application. */
     state?: string;
+    /** URL of the Apache Spark web UI that is available when the application is running. */
+    spark_ui?: string;
+    /** Time when the application was submitted. */
+    submission_time?: string;
     /** Time when the application was started. */
     start_time?: string;
     /** Time when the application run ended in success, failure or was stopped. */
     end_time?: string;
-    /** Time when the application was completed. */
+    /** (deprecated) Time when the application was completed. */
     finish_time?: string;
+    /** Time when the application will be automatically stopped by the service. */
+    auto_termination_time?: string;
   }
 
   /** An array of application details. */
@@ -1507,14 +1684,20 @@ namespace IbmAnalyticsEngineApiV3 {
     spark_application_name?: string;
     /** State of the Spark application. */
     state?: string;
+    /** URL of the Apache Spark web UI that is available when the application is running. */
+    spark_ui?: string;
     /** List of additional information messages on the current state of the application. */
     state_details?: ApplicationGetResponseStateDetailsItem[];
-    /** Application start time in the format YYYY-MM-DDTHH:mm:ssZ. */
+    /** Time when the application was submitted. */
+    submission_time?: string;
+    /** Time when the application started, in the format YYYY-MM-DDTHH:mm:ssZ. */
     start_time?: string;
-    /** Application end time in the format YYYY-MM-DDTHH:mm:ssZ. */
+    /** Time when the application ended either in success or failure, in the format YYYY-MM-DDTHH:mm:ssZ. */
     end_time?: string;
-    /** Application finish time in the format YYYY-MM-DDTHH:mm:ssZ. */
+    /** (deprecated) Time when the application completed successfully, in the format YYYY-MM-DDTHH:mm:ssZ. */
     finish_time?: string;
+    /** Time when the application will be automatically stopped by the service. */
+    auto_termination_time?: string;
   }
 
   /** Additional information message on the current state of the application. */
@@ -1537,8 +1720,10 @@ namespace IbmAnalyticsEngineApiV3 {
     start_time?: string;
     /** Time when the application run ended in success, failure or was stopped. */
     end_time?: string;
-    /** Time when the application was completed. */
+    /** (deprecated) Time when the application was completed. */
     finish_time?: string;
+    /** Time when the application will be automatically stopped by the service. */
+    auto_termination_time?: string;
   }
 
   /** Application details. */
@@ -1681,7 +1866,7 @@ namespace IbmAnalyticsEngineApiV3 {
     type?: string;
   }
 
-  /** Response of logging API. */
+  /** (deprecated) Response of logging API. */
   export interface LoggingConfigurationResponse {
     /** component array. */
     components?: string[];
@@ -1709,6 +1894,22 @@ namespace IbmAnalyticsEngineApiV3 {
   export interface Runtime {
     /** Spark version of the runtime environment. */
     spark_version?: string;
+  }
+
+  /** Status of the Spark history server. */
+  export interface SparkHistoryServerResponse {
+    /** State of the Spark history server. */
+    state?: string;
+    /** Number of cpu cores used by the Spark history server. */
+    cores?: string;
+    /** Amount of memory used by the Spark history server. */
+    memory?: string;
+    /** Time when the Spark history server was started. */
+    start_time?: string;
+    /** Time when the Spark history server was stopped. */
+    stop_time?: string;
+    /** Time when the Spark history server will be stopped automatically. */
+    auto_termination_time?: string;
   }
 }
 

--- a/test/integration/ibm-analytics-engine-api.v3.test.js
+++ b/test/integration/ibm-analytics-engine-api.v3.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -190,7 +190,7 @@ describe('IbmAnalyticsEngineApiV3_integration', () => {
   test('listApplications()', async () => {
     const params = {
       instanceId: instanceGuid,
-      state: ['accepted', 'submitted', 'waiting', 'running', 'finished', 'failed'],
+      state: ['accepted', 'running', 'finished', 'failed'],
     };
 
     const res = await ibmAnalyticsEngineApiService.listApplications(params);
@@ -282,6 +282,36 @@ describe('IbmAnalyticsEngineApiV3_integration', () => {
     const res = await ibmAnalyticsEngineApiService.getLoggingConfiguration(params);
     expect(res).toBeDefined();
     expect(res.status).toBe(200);
+    expect(res.result).toBeDefined();
+  });
+  test('startSparkHistoryServer()', async () => {
+    const params = {
+      instanceId: instanceGuid,
+    };
+
+    const res = await ibmAnalyticsEngineApiService.startSparkHistoryServer(params);
+    expect(res).toBeDefined();
+    expect(res.status).toBe(202);
+    expect(res.result).toBeDefined();
+  });
+  test('getSparkHistoryServer()', async () => {
+    const params = {
+      instanceId: instanceGuid,
+    };
+
+    const res = await ibmAnalyticsEngineApiService.getSparkHistoryServer(params);
+    expect(res).toBeDefined();
+    expect(res.status).toBe(200);
+    expect(res.result).toBeDefined();
+  });
+  test('stopSparkHistoryServer()', async () => {
+    const params = {
+      instanceId: instanceGuid,
+    };
+
+    const res = await ibmAnalyticsEngineApiService.stopSparkHistoryServer(params);
+    expect(res).toBeDefined();
+    expect(res.status).toBe(204);
     expect(res.result).toBeDefined();
   });
   test('deleteApplication()', async () => {

--- a/test/unit/ibm-analytics-engine-api.v3.test.js
+++ b/test/unit/ibm-analytics-engine-api.v3.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -302,8 +302,8 @@ describe('IbmAnalyticsEngineApiV3', () => {
         const newType = 'objectstore';
         const newRegion = 'us-south';
         const newEndpoint = 's3.direct.us-south.cloud-object-storage.appdomain.cloud';
-        const newHmacAccessKey = '821**********0ae';
-        const newHmacSecretKey = '03e****************4fc3';
+        const newHmacAccessKey = 'b9****************************4b';
+        const newHmacSecretKey = 'fa********************************************8a';
         const setInstanceHomeParams = {
           instanceId,
           newInstanceId,
@@ -883,7 +883,7 @@ describe('IbmAnalyticsEngineApiV3', () => {
 
       // ApplicationRequestApplicationDetails
       const applicationRequestApplicationDetailsModel = {
-        application: 'cos://bucket_name.my_cos/my_spark_app.py',
+        application: '/opt/ibm/spark/examples/src/main/python/wordcount.py',
         runtime: runtimeModel,
         jars: 'cos://cloud-object-storage/jars/tests.jar',
         packages: 'testString',
@@ -892,7 +892,7 @@ describe('IbmAnalyticsEngineApiV3', () => {
         archives: 'testString',
         name: 'spark-app',
         class: 'com.company.path.ClassName',
-        arguments: ['[arg1, arg2, arg3]'],
+        arguments: ['/opt/ibm/spark/examples/src/main/resources/people.txt'],
         conf: { 'key1': 'testString' },
         env: { 'key1': 'testString' },
       };
@@ -1908,6 +1908,276 @@ describe('IbmAnalyticsEngineApiV3', () => {
         let err;
         try {
           await ibmAnalyticsEngineApiService.getLoggingConfiguration();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('startSparkHistoryServer', () => {
+    describe('positive tests', () => {
+      function __startSparkHistoryServerTest() {
+        // Construct the params object for operation startSparkHistoryServer
+        const instanceId = 'e64c907a-e82f-46fd-addc-ccfafbd28b09';
+        const startSparkHistoryServerParams = {
+          instanceId,
+        };
+
+        const startSparkHistoryServerResult = ibmAnalyticsEngineApiService.startSparkHistoryServer(
+          startSparkHistoryServerParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(startSparkHistoryServerResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/v3/analytics_engines/{instance_id}/spark_history_server',
+          'POST'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __startSparkHistoryServerTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        ibmAnalyticsEngineApiService.enableRetries();
+        __startSparkHistoryServerTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        ibmAnalyticsEngineApiService.disableRetries();
+        __startSparkHistoryServerTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const instanceId = 'e64c907a-e82f-46fd-addc-ccfafbd28b09';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const startSparkHistoryServerParams = {
+          instanceId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        ibmAnalyticsEngineApiService.startSparkHistoryServer(startSparkHistoryServerParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await ibmAnalyticsEngineApiService.startSparkHistoryServer({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await ibmAnalyticsEngineApiService.startSparkHistoryServer();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('getSparkHistoryServer', () => {
+    describe('positive tests', () => {
+      function __getSparkHistoryServerTest() {
+        // Construct the params object for operation getSparkHistoryServer
+        const instanceId = 'e64c907a-e82f-46fd-addc-ccfafbd28b09';
+        const getSparkHistoryServerParams = {
+          instanceId,
+        };
+
+        const getSparkHistoryServerResult = ibmAnalyticsEngineApiService.getSparkHistoryServer(
+          getSparkHistoryServerParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(getSparkHistoryServerResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/v3/analytics_engines/{instance_id}/spark_history_server',
+          'GET'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getSparkHistoryServerTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        ibmAnalyticsEngineApiService.enableRetries();
+        __getSparkHistoryServerTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        ibmAnalyticsEngineApiService.disableRetries();
+        __getSparkHistoryServerTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const instanceId = 'e64c907a-e82f-46fd-addc-ccfafbd28b09';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getSparkHistoryServerParams = {
+          instanceId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        ibmAnalyticsEngineApiService.getSparkHistoryServer(getSparkHistoryServerParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await ibmAnalyticsEngineApiService.getSparkHistoryServer({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await ibmAnalyticsEngineApiService.getSparkHistoryServer();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('stopSparkHistoryServer', () => {
+    describe('positive tests', () => {
+      function __stopSparkHistoryServerTest() {
+        // Construct the params object for operation stopSparkHistoryServer
+        const instanceId = 'e64c907a-e82f-46fd-addc-ccfafbd28b09';
+        const stopSparkHistoryServerParams = {
+          instanceId,
+        };
+
+        const stopSparkHistoryServerResult = ibmAnalyticsEngineApiService.stopSparkHistoryServer(
+          stopSparkHistoryServerParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(stopSparkHistoryServerResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/v3/analytics_engines/{instance_id}/spark_history_server',
+          'DELETE'
+        );
+        const expectedAccept = undefined;
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __stopSparkHistoryServerTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        ibmAnalyticsEngineApiService.enableRetries();
+        __stopSparkHistoryServerTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        ibmAnalyticsEngineApiService.disableRetries();
+        __stopSparkHistoryServerTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const instanceId = 'e64c907a-e82f-46fd-addc-ccfafbd28b09';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const stopSparkHistoryServerParams = {
+          instanceId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        ibmAnalyticsEngineApiService.stopSparkHistoryServer(stopSparkHistoryServerParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await ibmAnalyticsEngineApiService.stopSparkHistoryServer({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await ibmAnalyticsEngineApiService.stopSparkHistoryServer();
         } catch (e) {
           err = e;
         }


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

1. Add api methods for managing spark history server.
2. Add submission_time and auto_termination_time fields in spark application list and details responses.

Signed-off-by: Subin Shekhar <subinpc@gmail.com>

**Fixes:** <! -- link to issue -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
